### PR TITLE
Remove `BJ Cree` from archived data to resolve conflict with `BJCree`

### DIFF
--- a/font-packages/dev/index.d.ts
+++ b/font-packages/dev/index.d.ts
@@ -8498,22 +8498,6 @@ export const BBHSansBartle_400Regular: string;
 /**
   * @deprecated This font has been removed from Google Fonts.
   */
-export const BJCree_400Regular: string;
-/**
-  * @deprecated This font has been removed from Google Fonts.
-  */
-export const BJCree_500Medium: string;
-/**
-  * @deprecated This font has been removed from Google Fonts.
-  */
-export const BJCree_600SemiBold: string;
-/**
-  * @deprecated This font has been removed from Google Fonts.
-  */
-export const BJCree_700Bold: string;
-/**
-  * @deprecated This font has been removed from Google Fonts.
-  */
 export const Finlandica_400Regular: string;
 /**
   * @deprecated This font has been removed from Google Fonts.

--- a/font-packages/dev/index.js
+++ b/font-packages/dev/index.js
@@ -8498,22 +8498,6 @@ export const BBHSansBartle_400Regular = 'https://fonts.gstatic.com/s/bbhsansbart
 /**
   * @deprecated This font has been removed from Google Fonts.
   */
-export const BJCree_400Regular = 'https://fonts.gstatic.com/s/bjcree/v1/8QIJdijLoYvJ7b7buIgOq7jkAOw.ttf';
-/**
-  * @deprecated This font has been removed from Google Fonts.
-  */
-export const BJCree_500Medium = 'https://fonts.gstatic.com/s/bjcree/v1/8QIMdijLoYvJ7b7bgHwnj7DPHOVyNYM.ttf';
-/**
-  * @deprecated This font has been removed from Google Fonts.
-  */
-export const BJCree_600SemiBold = 'https://fonts.gstatic.com/s/bjcree/v1/8QIMdijLoYvJ7b7bgFAgj7DPHOVyNYM.ttf';
-/**
-  * @deprecated This font has been removed from Google Fonts.
-  */
-export const BJCree_700Bold = 'https://fonts.gstatic.com/s/bjcree/v1/8QIMdijLoYvJ7b7bgDQhj7DPHOVyNYM.ttf';
-/**
-  * @deprecated This font has been removed from Google Fonts.
-  */
 export const Finlandica_400Regular = 'https://fonts.gstatic.com/s/finlandica/v10/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19A7rEjx9i5ss3a3.ttf';
 /**
   * @deprecated This font has been removed from Google Fonts.

--- a/font-packages/dev/package.json
+++ b/font-packages/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo-google-fonts/dev",
-  "version": "0.4.71",
+  "version": "0.4.72",
   "description": "Load 1943 font families from Google Fonts over the network while developing your Expo app",
   "main": "index.js",
   "repository": {

--- a/packages/generator/data/archived-data.json
+++ b/packages/generator/data/archived-data.json
@@ -1087,30 +1087,6 @@
       "menu": "https://fonts.gstatic.com/s/bbhsansbartle/v1/eLGEP-v-CSnwOk_evJ1qrrCJCQT59Owl.ttf"
     },
     {
-      "family": "BJ Cree",
-      "variants": [
-        "regular",
-        "500",
-        "600",
-        "700"
-      ],
-      "subsets": [
-        "canadian-aboriginal",
-        "latin"
-      ],
-      "version": "v1",
-      "lastModified": "2026-04-02",
-      "files": {
-        "500": "https://fonts.gstatic.com/s/bjcree/v1/8QIMdijLoYvJ7b7bgHwnj7DPHOVyNYM.ttf",
-        "600": "https://fonts.gstatic.com/s/bjcree/v1/8QIMdijLoYvJ7b7bgFAgj7DPHOVyNYM.ttf",
-        "700": "https://fonts.gstatic.com/s/bjcree/v1/8QIMdijLoYvJ7b7bgDQhj7DPHOVyNYM.ttf",
-        "regular": "https://fonts.gstatic.com/s/bjcree/v1/8QIJdijLoYvJ7b7buIgOq7jkAOw.ttf"
-      },
-      "category": "serif",
-      "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bjcree/v1/8QIJdijLoYvJ7b7biIkErw.ttf"
-    },
-    {
       "family": "Finlandica",
       "variants": [
         "regular",


### PR DESCRIPTION
https://github.com/google/fonts/issues/10225

`BJ Cree` was intended to be published as `BJCree`, so the original `BJ Cree` entry was removed and replaced with `BJCree`.
This caused a conflict in our `dev` package, so we need to manually delete `BJ Cree` from the font-archive to prevent it from being included in the `dev` package.

Closes #257
