### PR TITLE
Add license for `Tinos`

### DIFF
--- a/packages/generator/src/licenseOverrides.ts
+++ b/packages/generator/src/licenseOverrides.ts
@@ -33,6 +33,13 @@ export const licenseOverrides: [string[], { type: string; url?: string; content?
     },
   ],
   [
+    ['Tinos'],
+    {
+      type: FontLicenseTypes.OFL,
+      url: 'https://raw.githubusercontent.com/googlefonts/tinos/refs/heads/main/OFL.txt',
+    },
+  ],
+  [
     ['Edu QLD Hand'],
     {
       type: FontLicenseTypes.OFL,


### PR DESCRIPTION
`Tinos` does not include a license file in the Google Fonts repository, but the correct OFL license is present in the `googlefonts/tinos` repository. This PR adds a license override for Tinos pointing to this license file: https://github.com/googlefonts/tinos/blob/main/OFL.txt